### PR TITLE
feature: extended support for incidents types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.4
+
+* Extended support for all types of incidents.
+
 ## 0.1.3
 
 * Handling HTTP error 420 Enhance Your Calm.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Initially we support the following functionality:
 - Get specific page by id
 - Get list of components by page
 - Get component by id by page
+- Get list of incidents
 - Get page info and components summarized
 
 In the following versions we'll be adding more more functionality
@@ -65,6 +66,10 @@ final page = await statusPage.page('PAGE_ID');
 final componentList = page.components;
 
 final component = page.component('COMPONENT_ID');
+
+final incidentList = await statusPage.incidents;
+
+final unresolvedIncidents = await statusPage.incidents('PAGE_ID', IncidentType.unresolved);
 
 final summary = StatusPage.summary(url: 'YOUR_DOMAIN_URL');
 

--- a/lib/enums/incident_type.dart
+++ b/lib/enums/incident_type.dart
@@ -1,0 +1,1 @@
+enum IncidentType { maintenance, scheduled, unresolved, upcoming }

--- a/lib/network/status_page_api.dart
+++ b/lib/network/status_page_api.dart
@@ -20,6 +20,19 @@ abstract class StatusPageApi {
   @GET("/pages/{pageId}/components")
   Future<List<Component>> getComponents(@Path() String pageId);
 
+  @GET("/pages/{pageId}/incidents")
+  Future<List<Incident>> getIncidents(@Path() String pageId);
+
+  @GET("/pages/{pageId}/incidents/active_maintenance")
+  Future<List<Incident>> getActiveMaintenanceIncidents(@Path() String pageId);
+
+  @GET("/pages/{pageId}/incidents/scheduled")
+  Future<List<Incident>> getScheduledIncidents(@Path() String pageId);
+
   @GET("/pages/{pageId}/incidents/unresolved")
   Future<List<Incident>> getUnresolvedIncidents(@Path() String pageId);
+
+  @GET("/pages/{pageId}/incidents/upcoming")
+  Future<List<Incident>> getUpcomingIncidents(@Path() String pageId);
 }
+

--- a/lib/status_page.dart
+++ b/lib/status_page.dart
@@ -4,6 +4,8 @@ import 'package:json_annotation/json_annotation.dart';
 import 'package:dio/dio.dart';
 import 'package:retrofit/retrofit.dart';
 
+import 'enums/incident_type.dart';
+
 part 'models/page.dart';
 
 part 'models/incident.dart';
@@ -48,10 +50,20 @@ class StatusPage {
     }
   }
 
-  Future<List<Incident>> incidents(String pageId) async {
+  Future<List<Incident>> incidents(String pageId, [IncidentType? incidentType]) async {
     try {
-      final incidents = await _statusPageApi.getUnresolvedIncidents(pageId);
-      return incidents;
+      switch (incidentType) {
+        case IncidentType.maintenance:
+          return await _statusPageApi.getActiveMaintenanceIncidents(pageId);
+        case IncidentType.scheduled:
+          return await _statusPageApi.getScheduledIncidents(pageId);
+        case IncidentType.unresolved:
+          return await _statusPageApi.getUnresolvedIncidents(pageId);
+        case IncidentType.upcoming:
+          return await _statusPageApi.getUpcomingIncidents(pageId);
+        default:
+          return await _statusPageApi.getIncidents(pageId);
+        }
     } on DioError catch (error) {
       throw _handleError(error);
     }

--- a/lib/status_page.g.dart
+++ b/lib/status_page.g.dart
@@ -219,10 +219,13 @@ Map<String, dynamic> _$SummaryToJson(Summary instance) => <String, dynamic>{
 // RetrofitGenerator
 // **************************************************************************
 
-// ignore_for_file: unnecessary_brace_in_string_interps
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers
 
 class _StatusPageApi implements StatusPageApi {
-  _StatusPageApi(this._dio, {this.baseUrl}) {
+  _StatusPageApi(
+    this._dio, {
+    this.baseUrl,
+  }) {
     baseUrl ??= 'https://api.statuspage.io/v1';
   }
 
@@ -236,10 +239,18 @@ class _StatusPageApi implements StatusPageApi {
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
-    final _result = await _dio.fetch<List<dynamic>>(_setStreamType<List<Page>>(
-        Options(method: 'GET', headers: _headers, extra: _extra)
-            .compose(_dio.options, '/pages',
-                queryParameters: queryParameters, data: _data)
+    final _result =
+        await _dio.fetch<List<dynamic>>(_setStreamType<List<Page>>(Options(
+      method: 'GET',
+      headers: _headers,
+      extra: _extra,
+    )
+            .compose(
+              _dio.options,
+              '/pages',
+              queryParameters: queryParameters,
+              data: _data,
+            )
             .copyWith(baseUrl: baseUrl ?? _dio.options.baseUrl)));
     var value = _result.data!
         .map((dynamic i) => Page.fromJson(i as Map<String, dynamic>))
@@ -253,10 +264,18 @@ class _StatusPageApi implements StatusPageApi {
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
-    final _result = await _dio.fetch<Map<String, dynamic>>(_setStreamType<Page>(
-        Options(method: 'GET', headers: _headers, extra: _extra)
-            .compose(_dio.options, '/pages/${pageId}',
-                queryParameters: queryParameters, data: _data)
+    final _result =
+        await _dio.fetch<Map<String, dynamic>>(_setStreamType<Page>(Options(
+      method: 'GET',
+      headers: _headers,
+      extra: _extra,
+    )
+            .compose(
+              _dio.options,
+              '/pages/${pageId}',
+              queryParameters: queryParameters,
+              data: _data,
+            )
             .copyWith(baseUrl: baseUrl ?? _dio.options.baseUrl)));
     final value = Page.fromJson(_result.data!);
     return value;
@@ -268,14 +287,96 @@ class _StatusPageApi implements StatusPageApi {
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
-    final _result = await _dio.fetch<List<dynamic>>(
-        _setStreamType<List<Component>>(
-            Options(method: 'GET', headers: _headers, extra: _extra)
-                .compose(_dio.options, '/pages/${pageId}/components',
-                    queryParameters: queryParameters, data: _data)
-                .copyWith(baseUrl: baseUrl ?? _dio.options.baseUrl)));
+    final _result =
+        await _dio.fetch<List<dynamic>>(_setStreamType<List<Component>>(Options(
+      method: 'GET',
+      headers: _headers,
+      extra: _extra,
+    )
+            .compose(
+              _dio.options,
+              '/pages/${pageId}/components',
+              queryParameters: queryParameters,
+              data: _data,
+            )
+            .copyWith(baseUrl: baseUrl ?? _dio.options.baseUrl)));
     var value = _result.data!
         .map((dynamic i) => Component.fromJson(i as Map<String, dynamic>))
+        .toList();
+    return value;
+  }
+
+  @override
+  Future<List<Incident>> getIncidents(pageId) async {
+    const _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    final _result =
+        await _dio.fetch<List<dynamic>>(_setStreamType<List<Incident>>(Options(
+      method: 'GET',
+      headers: _headers,
+      extra: _extra,
+    )
+            .compose(
+              _dio.options,
+              '/pages/${pageId}/incidents',
+              queryParameters: queryParameters,
+              data: _data,
+            )
+            .copyWith(baseUrl: baseUrl ?? _dio.options.baseUrl)));
+    var value = _result.data!
+        .map((dynamic i) => Incident.fromJson(i as Map<String, dynamic>))
+        .toList();
+    return value;
+  }
+
+  @override
+  Future<List<Incident>> getActiveMaintenanceIncidents(pageId) async {
+    const _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    final _result =
+        await _dio.fetch<List<dynamic>>(_setStreamType<List<Incident>>(Options(
+      method: 'GET',
+      headers: _headers,
+      extra: _extra,
+    )
+            .compose(
+              _dio.options,
+              '/pages/${pageId}/incidents/active_maintenance',
+              queryParameters: queryParameters,
+              data: _data,
+            )
+            .copyWith(baseUrl: baseUrl ?? _dio.options.baseUrl)));
+    var value = _result.data!
+        .map((dynamic i) => Incident.fromJson(i as Map<String, dynamic>))
+        .toList();
+    return value;
+  }
+
+  @override
+  Future<List<Incident>> getScheduledIncidents(pageId) async {
+    const _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    final _result =
+        await _dio.fetch<List<dynamic>>(_setStreamType<List<Incident>>(Options(
+      method: 'GET',
+      headers: _headers,
+      extra: _extra,
+    )
+            .compose(
+              _dio.options,
+              '/pages/${pageId}/incidents/scheduled',
+              queryParameters: queryParameters,
+              data: _data,
+            )
+            .copyWith(baseUrl: baseUrl ?? _dio.options.baseUrl)));
+    var value = _result.data!
+        .map((dynamic i) => Incident.fromJson(i as Map<String, dynamic>))
         .toList();
     return value;
   }
@@ -286,12 +387,44 @@ class _StatusPageApi implements StatusPageApi {
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
     final _data = <String, dynamic>{};
-    final _result = await _dio.fetch<List<dynamic>>(
-        _setStreamType<List<Incident>>(
-            Options(method: 'GET', headers: _headers, extra: _extra)
-                .compose(_dio.options, '/pages/${pageId}/incidents/unresolved',
-                    queryParameters: queryParameters, data: _data)
-                .copyWith(baseUrl: baseUrl ?? _dio.options.baseUrl)));
+    final _result =
+        await _dio.fetch<List<dynamic>>(_setStreamType<List<Incident>>(Options(
+      method: 'GET',
+      headers: _headers,
+      extra: _extra,
+    )
+            .compose(
+              _dio.options,
+              '/pages/${pageId}/incidents/unresolved',
+              queryParameters: queryParameters,
+              data: _data,
+            )
+            .copyWith(baseUrl: baseUrl ?? _dio.options.baseUrl)));
+    var value = _result.data!
+        .map((dynamic i) => Incident.fromJson(i as Map<String, dynamic>))
+        .toList();
+    return value;
+  }
+
+  @override
+  Future<List<Incident>> getUpcomingIncidents(pageId) async {
+    const _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    final _result =
+        await _dio.fetch<List<dynamic>>(_setStreamType<List<Incident>>(Options(
+      method: 'GET',
+      headers: _headers,
+      extra: _extra,
+    )
+            .compose(
+              _dio.options,
+              '/pages/${pageId}/incidents/upcoming',
+              queryParameters: queryParameters,
+              data: _data,
+            )
+            .copyWith(baseUrl: baseUrl ?? _dio.options.baseUrl)));
     var value = _result.data!
         .map((dynamic i) => Incident.fromJson(i as Map<String, dynamic>))
         .toList();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: status_page
 description: Library to consume Atlassian's Status Page API from dart.
-version: 0.1.3
+version: 0.1.4
 homepage: https://github.com/Fondeadora/status_page_dart
 
 environment:

--- a/test/status_page_test.dart
+++ b/test/status_page_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:status_page/enums/incident_type.dart';
 import 'package:status_page/status_page.dart';
 
 void main() async {
@@ -68,16 +69,44 @@ void main() async {
       });
     });
 
+    test('success getting all incidents', () async {
+      await handleRateLimiting(() async {
+        final incidents = await statusPage.incidents(testPage);
+        expect(incidents, isNot(null));
+      });
+    });
+
+    test('success getting active maintenance incidents', () async {
+      await handleRateLimiting(() async {
+        final incidents = await statusPage.incidents(testPage, IncidentType.maintenance);
+        expect(incidents, isNot(null));
+      });
+    });
+
     test('success getting unresolved incidents', () async {
       await handleRateLimiting(() async {
-        final unresolvedIncidents = await statusPage.incidents(testPage);
-        expect(unresolvedIncidents, isNot(null));
+        final incidents = await statusPage.incidents(testPage, IncidentType.unresolved);
+        expect(incidents, isNot(null));
+      });
+    });
+
+    test('success getting scheduled incidents', () async {
+      await handleRateLimiting(() async {
+        final incidents = await statusPage.incidents(testPage, IncidentType.scheduled);
+        expect(incidents, isNot(null));
+      });
+    });
+
+    test('success getting upcoming incidents', () async {
+      await handleRateLimiting(() async {
+        final incidents = await statusPage.incidents(testPage, IncidentType.upcoming);
+        expect(incidents, isNot(null));
       });
     });
 
     test('success getting latest unresolved incident', () async {
       await handleRateLimiting(() async {
-        final unresolvedIncidents = await statusPage.incidents(testPage);
+        final unresolvedIncidents = await statusPage.incidents(testPage, IncidentType.unresolved);
         if (unresolvedIncidents.isNotEmpty) {
           final latestIncident = unresolvedIncidents.latest;
           expect(latestIncident, isNot(null));


### PR DESCRIPTION
### Description
The Statuspage API documentation supports different types of incidents, whereas this package only supports a subset.

### What is the current behavior?
When trying to retrieve a list of `incidents`, the function `getUnresolvedIncidents(pageId)` calls upon `@GET("/pages/{pageId}/incidents/unresolved")`.

### What is the new behavior?
When trying to retrieve `incidents`, there is a second (optional) parameter `IncidentType`. When `null`, it calls upon `@GET("/pages/{pageId}/incidents")` which lists all incidents types. But when a specific (`Enum`) type is provided, it specifically retrieves that incident type.

### How was it tested?
- [x] integration

### Checklist
- [x] Does your code follow the project style guide?
- [x] Have you added tests that cover the changes and run them?
- [x] Have you updated the documentation as needed?
